### PR TITLE
Adding Stop script + How to configure Ochothon

### DIFF
--- a/mesos/README.md
+++ b/mesos/README.md
@@ -28,4 +28,5 @@ This setup include:
 * Add the following env variables to dcos.json definition:
  * "MARATHON_MASTER": "MESOS_LOCALSETUP_HOST_IP:5051",
  *  "ochopod_zk" : "zk://MESOS_LOCAL_SETUP_HOST_IP:2181"
-* You must replace MESOS_LOCALSETUP_HOST_IP with the actual value 
+* You must replace MESOS_LOCALSETUP_HOST_IP with the actual value
+* You must delete the mesosphere volumes tag

--- a/mesos/README.md
+++ b/mesos/README.md
@@ -29,4 +29,3 @@ This setup include:
  * "MARATHON_MASTER": "MESOS_LOCALSETUP_HOST_IP:5051",
  *  "ochopod_zk" : "zk://MESOS_LOCAL_SETUP_HOST_IP:2181"
 * You must replace MESOS_LOCALSETUP_HOST_IP with the actual value
-* You must delete the mesosphere volumes tag

--- a/mesos/README.md
+++ b/mesos/README.md
@@ -22,3 +22,10 @@ This setup include:
   export MESOS_LOCALSETUP_HOST_IP=`docker-machine ip mesos_local`
   ```
 * Run ```sh start.sh``` to spin up Mesos local setup
+* Run ```sh stop.sh``` to stop up Mesos local setup and all Marathon started containers
+
+## How to add Ochothon
+* Add the following env variables to dcos.json definition:
+ * "MARATHON_MASTER": "MESOS_LOCALSETUP_HOST_IP:5051",
+ *  "ochopod_zk" : "zk://MESOS_LOCAL_SETUP_HOST_IP:2181"
+* You must replace MESOS_LOCALSETUP_HOST_IP with the actual value 

--- a/mesos/mesos-slave/Dockerfile
+++ b/mesos/mesos-slave/Dockerfile
@@ -1,6 +1,12 @@
 FROM quay.io/autodeskcloud/mesos-base
 
 RUN apt-get install -y unzip
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates
+
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+RUN echo deb https://apt.dockerproject.org/repo debian-jessie main >> /etc/apt/sources.list.d/docker.list
+
+RUN apt-get update && apt-get install -y docker-engine
 
 EXPOSE 5051
 CMD ["mesos-slave"]

--- a/mesos/stop.sh
+++ b/mesos/stop.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+docker stop mesos_local_zk mesos_local_mesos_master mesos_local_mesos_slave mesos_local_marathon
+docker stop `docker ps --filter="name=mesos-.*" -q`
+docker rm `docker ps -a -q`
+
+echo "Showing containers still running"
+docker ps


### PR DESCRIPTION
Stop script will stop all running mesos (docker) containers (including those started by Marathon).
If any container fails to stop, it will be listed at the end of the script.

How to configure Ochothon shows main differences between DCOS setup and local setup.
